### PR TITLE
fix #18: set GitHub panel color to match on mobile/small screens

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -126,3 +126,11 @@ body {
 [data-md-color-scheme="slate"] .md-nav .md-nav__link--active:hover {
   color: var(--color-turquoise);
 }
+
+/* Small screen adjustments */
+@media screen and (max-width: 76.2344em) {
+  /* Dark mode custom active parent color (side panel) */
+  [data-md-color-scheme="slate"] .md-nav .md-nav__item--active > .md-nav__link {
+    color: var(--color-gb-contrast);
+  } 
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -132,5 +132,12 @@ body {
   /* Dark mode custom active parent color (side panel) */
   [data-md-color-scheme="slate"] .md-nav .md-nav__item--active > .md-nav__link {
     color: var(--color-gb-contrast);
+  }
+}
+
+@media screen and (max-width: 76.2344em) {
+  /* Dark mode custom active parent hover color (side panel) */
+  [data-md-color-scheme="slate"] .md-nav .md-nav__item--active:hover > .md-nav__link {
+    color: var(--color-turquoise);
   } 
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -133,11 +133,9 @@ body {
   [data-md-color-scheme="slate"] .md-nav .md-nav__item--active > .md-nav__link {
     color: var(--color-gb-contrast);
   }
-}
-
-@media screen and (max-width: 76.2344em) {
+  
   /* Dark mode custom active parent hover color (side panel) */
   [data-md-color-scheme="slate"] .md-nav .md-nav__item--active:hover > .md-nav__link {
     color: var(--color-turquoise);
-  } 
+  }
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -42,6 +42,15 @@ body {
   --md-accent-fg-color:         var(--color-turquoise);
 }
 
+/* GitHub panel color (mobile and small screen, issue 18) */
+.md-nav__source {
+  background-color: var(--md-primary-fg-color);
+}
+
+.md-source {
+  background-color: var(--md-primary-fg-color);
+}
+
 /* Set admonition (Note) colors to stand out better */
 .md-typeset .admonition.note, .md-typeset details.note {
     border-color: var(--color-turquoise);


### PR DESCRIPTION
When the browser window is narrower, the GitHub panel shows up in the menu on the side and its color must be set manually. This PR does that so that it will match the the primary color. See screenshots below.
<p>
<img width="49%" alt="lightmode fix GH panel matches primary color" src="https://github.com/user-attachments/assets/5f666711-4be3-4052-b238-630d1c46b766" />
<img width="42%" alt="darkmode fix GH panel matches primary color" src="https://github.com/user-attachments/assets/718e8b17-2c87-4e29-8c41-ecee9e56e596" />
</p>

Fixes #18. 